### PR TITLE
Enable comments

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
             android:name=".view.FeedActivity"
             android:exported="false" />
         <activity
+            android:name=".view.CommentsActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/example/androidjavainstagramclone/adapter/CommentAdapter.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/adapter/CommentAdapter.java
@@ -1,0 +1,48 @@
+package com.example.androidjavainstagramclone.adapter;
+
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.androidjavainstagramclone.databinding.CommentRowBinding;
+import com.example.androidjavainstagramclone.model.Comment;
+
+import java.util.ArrayList;
+
+public class CommentAdapter extends RecyclerView.Adapter<CommentAdapter.CommentHolder> {
+
+    private ArrayList<Comment> commentArrayList;
+
+    public CommentAdapter(ArrayList<Comment> commentArrayList) {
+        this.commentArrayList = commentArrayList;
+    }
+
+    @NonNull
+    @Override
+    public CommentHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        CommentRowBinding binding = CommentRowBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+        return new CommentHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull CommentHolder holder, int position) {
+        holder.binding.commentUserEmail.setText(commentArrayList.get(position).userEmail);
+        holder.binding.commentText.setText(commentArrayList.get(position).text);
+    }
+
+    @Override
+    public int getItemCount() {
+        return commentArrayList.size();
+    }
+
+    class CommentHolder extends RecyclerView.ViewHolder {
+        CommentRowBinding binding;
+
+        public CommentHolder(CommentRowBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidjavainstagramclone/adapter/PostAdapter.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/adapter/PostAdapter.java
@@ -1,5 +1,6 @@
 package com.example.androidjavainstagramclone.adapter;
 
+import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -9,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.androidjavainstagramclone.databinding.RecyclerRowBinding;
 import com.example.androidjavainstagramclone.model.Post;
+import com.example.androidjavainstagramclone.view.CommentsActivity;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
@@ -33,6 +35,15 @@ public class PostAdapter extends RecyclerView.Adapter<PostAdapter.PostHolder> {
         holder.recyclerRowBinding.recyclerViewUserEmailText.setText(postArrayList.get(position).email);
         holder.recyclerRowBinding.recyclerViewCommentText.setText(postArrayList.get(position).comment);
         Picasso.get().load(postArrayList.get(position).downloadUrl).into(holder.recyclerRowBinding.recyclerViewImageView);
+
+        holder.itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(v.getContext(), CommentsActivity.class);
+                intent.putExtra("postId", postArrayList.get(position).postId);
+                v.getContext().startActivity(intent);
+            }
+        });
 
     }
 

--- a/app/src/main/java/com/example/androidjavainstagramclone/model/Comment.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/model/Comment.java
@@ -1,0 +1,21 @@
+package com.example.androidjavainstagramclone.model;
+
+import com.google.firebase.Timestamp;
+
+public class Comment {
+    public String userEmail;
+    public String text;
+    public Timestamp date;
+    public String postId;
+
+    public Comment() {
+        // no-arg constructor for Firestore
+    }
+
+    public Comment(String userEmail, String text, Timestamp date, String postId) {
+        this.userEmail = userEmail;
+        this.text = text;
+        this.date = date;
+        this.postId = postId;
+    }
+}

--- a/app/src/main/java/com/example/androidjavainstagramclone/model/Post.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/model/Post.java
@@ -4,11 +4,17 @@ public class Post {
     public String email;
     public String comment;
     public String downloadUrl;
+    public String postId;
 
-    public Post(String email, String comment, String downloadUrl) {
+    public Post() {
+        // required empty constructor
+    }
+
+    public Post(String email, String comment, String downloadUrl, String postId) {
         this.email = email;
         this.comment = comment;
         this.downloadUrl = downloadUrl;
+        this.postId = postId;
     }
     @Override
     public String toString() {

--- a/app/src/main/java/com/example/androidjavainstagramclone/view/CommentsActivity.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/view/CommentsActivity.java
@@ -1,0 +1,107 @@
+package com.example.androidjavainstagramclone.view;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
+import com.example.androidjavainstagramclone.adapter.CommentAdapter;
+import com.example.androidjavainstagramclone.databinding.ActivityCommentsBinding;
+import com.example.androidjavainstagramclone.model.Comment;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.Timestamp;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommentsActivity extends AppCompatActivity {
+
+    private ActivityCommentsBinding binding;
+    private ArrayList<Comment> commentArrayList;
+    private CommentAdapter commentAdapter;
+    private FirebaseFirestore firebaseFirestore;
+    private FirebaseAuth auth;
+    private String postId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = ActivityCommentsBinding.inflate(getLayoutInflater());
+        View view = binding.getRoot();
+        setContentView(view);
+
+        postId = getIntent().getStringExtra("postId");
+        firebaseFirestore = FirebaseFirestore.getInstance();
+        auth = FirebaseAuth.getInstance();
+
+        commentArrayList = new ArrayList<>();
+        commentAdapter = new CommentAdapter(commentArrayList);
+        binding.commentsRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        binding.commentsRecyclerView.setAdapter(commentAdapter);
+
+        getComments();
+    }
+
+    private void getComments() {
+        if (postId == null) return;
+        firebaseFirestore.collection("posts").document(postId).collection("comments")
+                .orderBy("date", Query.Direction.ASCENDING)
+                .addSnapshotListener(new EventListener<QuerySnapshot>() {
+                    @Override
+                    public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                        if (error != null) {
+                            Toast.makeText(CommentsActivity.this, error.getLocalizedMessage(), Toast.LENGTH_LONG).show();
+                            return;
+                        }
+                        if (value != null) {
+                            commentArrayList.clear();
+                            for (DocumentSnapshot doc : value.getDocuments()) {
+                                Comment comment = doc.toObject(Comment.class);
+                                if (comment != null) {
+                                    commentArrayList.add(comment);
+                                }
+                            }
+                            commentAdapter.notifyDataSetChanged();
+                        }
+                    }
+                });
+    }
+
+    public void sendComment(View view) {
+        String text = binding.commentEditText.getText().toString();
+        if (text.isEmpty() || postId == null) return;
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("userEmail", auth.getCurrentUser() != null ? auth.getCurrentUser().getEmail() : "");
+        data.put("text", text);
+        data.put("date", Timestamp.now());
+        data.put("postId", postId);
+
+        CollectionReference ref = firebaseFirestore.collection("posts").document(postId).collection("comments");
+        ref.add(data).addOnSuccessListener(new OnSuccessListener<com.google.firebase.firestore.DocumentReference>() {
+            @Override
+            public void onSuccess(com.google.firebase.firestore.DocumentReference documentReference) {
+                binding.commentEditText.setText("");
+            }
+        }).addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                Toast.makeText(CommentsActivity.this, e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/example/androidjavainstagramclone/view/FeedActivity.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/view/FeedActivity.java
@@ -97,7 +97,7 @@ public class FeedActivity extends AppCompatActivity {
                         String  comment = (String) data.get("comment");
                         String  downloadUrl = (String) data.get("downloadurl");
 
-                        Post post=new Post(userEmail, comment, downloadUrl);
+                        Post post=new Post(userEmail, comment, downloadUrl, snapshot.getId());
                         postArrayList.add(post);
                     }
                     System.out.println("0"+postArrayList.get(0));

--- a/app/src/main/res/layout/activity_comments.xml
+++ b/app/src/main/res/layout/activity_comments.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/commentsRecyclerView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/commentInputLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/commentInputLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <EditText
+            android:id="@+id/commentEditText"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:hint="Add comment" />
+
+        <Button
+            android:id="@+id/sendCommentButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send"
+            android:onClick="sendComment" />
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/comment_row.xml
+++ b/app/src/main/res/layout/comment_row.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/commentUserEmail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="email"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/commentText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="comment" />
+</LinearLayout>

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /posts/{postId} {
+      allow read: if true;
+      allow write: if request.auth != null;
+      match /comments/{commentId} {
+        allow read: if true;
+        allow write: if request.auth != null;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create Comment model
- expand Post model with postId
- implement CommentAdapter and layout
- add CommentsActivity for viewing and sending comments
- launch CommentsActivity from PostAdapter
- expose comment layouts
- register new activity in manifest
- add Firestore rules for comments

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6882725dbba8832d9cb3b11ce1cf3634