### PR TITLE
Add comment like feature

### DIFF
--- a/app/src/main/java/com/example/androidjavainstagramclone/adapter/CommentAdapter.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/adapter/CommentAdapter.java
@@ -1,6 +1,7 @@
 package com.example.androidjavainstagramclone.adapter;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -8,6 +9,8 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.androidjavainstagramclone.databinding.CommentRowBinding;
 import com.example.androidjavainstagramclone.model.Comment;
+import com.google.firebase.firestore.FieldValue;
+import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
 
@@ -28,8 +31,22 @@ public class CommentAdapter extends RecyclerView.Adapter<CommentAdapter.CommentH
 
     @Override
     public void onBindViewHolder(@NonNull CommentHolder holder, int position) {
-        holder.binding.commentUserEmail.setText(commentArrayList.get(position).userEmail);
-        holder.binding.commentText.setText(commentArrayList.get(position).text);
+        Comment current = commentArrayList.get(position);
+        holder.binding.commentUserEmail.setText(current.userEmail);
+        holder.binding.commentText.setText(current.text);
+        holder.binding.likeCountTextView.setText(String.valueOf(current.likes));
+
+        holder.binding.likeButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                FirebaseFirestore.getInstance()
+                        .collection("posts")
+                        .document(current.postId)
+                        .collection("comments")
+                        .document(current.commentId)
+                        .update("likes", FieldValue.increment(1));
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/example/androidjavainstagramclone/model/Comment.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/model/Comment.java
@@ -7,15 +7,18 @@ public class Comment {
     public String text;
     public Timestamp date;
     public String postId;
+    public String commentId;
+    public long likes;
 
     public Comment() {
         // no-arg constructor for Firestore
     }
-
-    public Comment(String userEmail, String text, Timestamp date, String postId) {
+    public Comment(String userEmail, String text, Timestamp date, String postId, String commentId, long likes) {
         this.userEmail = userEmail;
         this.text = text;
         this.date = date;
         this.postId = postId;
+        this.commentId = commentId;
+        this.likes = likes;
     }
 }

--- a/app/src/main/java/com/example/androidjavainstagramclone/view/CommentsActivity.java
+++ b/app/src/main/java/com/example/androidjavainstagramclone/view/CommentsActivity.java
@@ -72,6 +72,10 @@ public class CommentsActivity extends AppCompatActivity {
                             for (DocumentSnapshot doc : value.getDocuments()) {
                                 Comment comment = doc.toObject(Comment.class);
                                 if (comment != null) {
+                                    comment.commentId = doc.getId();
+                                    if (doc.get("likes") == null) {
+                                        comment.likes = 0;
+                                    }
                                     commentArrayList.add(comment);
                                 }
                             }
@@ -90,6 +94,7 @@ public class CommentsActivity extends AppCompatActivity {
         data.put("text", text);
         data.put("date", Timestamp.now());
         data.put("postId", postId);
+        data.put("likes", 0);
 
         CollectionReference ref = firebaseFirestore.collection("posts").document(postId).collection("comments");
         ref.add(data).addOnSuccessListener(new OnSuccessListener<com.google.firebase.firestore.DocumentReference>() {

--- a/app/src/main/res/layout/comment_row.xml
+++ b/app/src/main/res/layout/comment_row.xml
@@ -17,4 +17,24 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="comment" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageButton
+            android:id="@+id/likeButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@android:drawable/btn_star_big_off" />
+
+        <TextView
+            android:id="@+id/likeCountTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="4dp"
+            android:text="0" />
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- let comments store `commentId` and `likes`
- display a like button with count for each comment
- update the like count in Firestore when button clicked
- initialize like count when sending a comment

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688278450384832d821ec53bf3de0b97